### PR TITLE
Fixed skipped hosts on ansible_local provision when doing vagrant up …

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
- 
+
   config.vm.box = "puppetlabs/centos-7.2-64-nocm"
   # config.vm.box_url = "http://atlas.hashicorp.com/centos/boxes/7"
   # config.vm.box_download_insecure = true
@@ -59,7 +59,7 @@ Vagrant.configure(2) do |config|
   #
   # View the documentation for the provider you are using for more
   # information on available options.
-  
+
   # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
   # such as FTP and Heroku are also available. See the documentation at
   # https://docs.vagrantup.com/v2/push/atlas.html for more information.
@@ -71,14 +71,16 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   #config.vm.provision "shell", inline: <<-SHELL
-  #  
+  #
   #  sudo apt-get install -y apache2
   #SHELL
-  
+
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "moira.yml"
     ansible.provisioning_path = "/vagrant/ansible"
     ansible.verbose  = false
     ansible.install  = true
+    ansible.inventory_path = "/vagrant/inventory"
+    ansible.limit = "app"
   end
 end

--- a/ansible/moira.yml
+++ b/ansible/moira.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: app
   become: yes
   roles:
     - common

--- a/ansible/moira_triggers.yml
+++ b/ansible/moira_triggers.yml
@@ -1,6 +1,6 @@
-- hosts: localhost
+- hosts: app
   become: yes
-  tasks: 
+  tasks:
     - name: requests must be installed
       pip: name=requests state=present
 
@@ -14,7 +14,7 @@
         - Moira
         - Normal
 
-    - name: Low Disk Space 
+    - name: Low Disk Space
       moira_trigger:
         url: "http://localhost:8081"
         name: "Low Disk Space"
@@ -25,7 +25,7 @@
         - Moira
         - Normal
 
-    - name: The machine was rebooted 
+    - name: The machine was rebooted
       moira_trigger:
         url: "http://localhost:8081"
         name: The machine was rebooted

--- a/inventory
+++ b/inventory
@@ -1,0 +1,2 @@
+[app]
+localhost ansible_connection=local

--- a/start_provision.sh
+++ b/start_provision.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ansible-playbook -i "localhost," -c local ansible/moira.yml
+ansible-playbook -i inventory ansible/moira.yml


### PR DESCRIPTION
Fixes:
- Now it works both when "vargant up" from clean machine, and running ./start-provision.sh from vagrant box
- Removed ambiguously usage of ansible inventory
- Assumed more universal usage of playbooks.

@beevee, @AlexAkulov - for review.
